### PR TITLE
Fix build issue

### DIFF
--- a/tfoclient.c
+++ b/tfoclient.c
@@ -1,13 +1,3 @@
-/* conditional define for TCP_FASTOPEN */
-#ifndef TCP_FASTOPEN
-#define TCP_FASTOPEN   23
-#endif
-
-/* conditional define for MSG_FASTOPEN */
-#ifndef MSG_FASTOPEN
-#define MSG_FASTOPEN   0x20000000
-#endif
-
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>
@@ -19,6 +9,16 @@
 #include <errno.h>
 #include <arpa/inet.h>
 #include <getopt.h>
+
+/* conditional define for TCP_FASTOPEN */
+#ifndef TCP_FASTOPEN
+#define TCP_FASTOPEN   23
+#endif
+
+/* conditional define for MSG_FASTOPEN */
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN   0x20000000
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/tfoserver.c
+++ b/tfoserver.c
@@ -1,13 +1,3 @@
-/* conditional define for TCP_FASTOPEN */
-#ifndef TCP_FASTOPEN
-#define TCP_FASTOPEN   23
-#endif
-
-/* conditional define for MSG_FASTOPEN */
-#ifndef MSG_FASTOPEN
-#define MSG_FASTOPEN   0x20000000
-#endif
-
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -20,6 +10,16 @@
 #include <time.h>
 #include <netinet/tcp.h>
 #include <getopt.h>
+
+/* conditional define for TCP_FASTOPEN */
+#ifndef TCP_FASTOPEN
+#define TCP_FASTOPEN   23
+#endif
+
+/* conditional define for MSG_FASTOPEN */
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN   0x20000000
+#endif
 
 struct conn {
     int fd;


### PR DESCRIPTION
Move defines after include to fix problem building from source.

gcc -g -Wall tfoclient.c -o tfoclient
tfoclient.c:8:24: error: expected identifier before numeric constant
 #define MSG_FASTOPEN   0x20000000
